### PR TITLE
Add private key import/export 

### DIFF
--- a/libprio.i
+++ b/libprio.i
@@ -200,17 +200,18 @@ EXPORT_KEY(PrivateKey, PrivateKey, export_hex, CURVE25519_KEY_LEN_HEX+1)
 // Memory shouldn't be moving around so much, but this wrapper function needs to exist in
 // order to marshal data due to typemaps not having side-effects
 
-%define MSGPACK_WRITE_WRAPPER(type)
-%ignore type ## _write;
+%define MSGPACK_WRITE(TYPE)
+%ignore TYPE ## _write;
+%rename(TYPE ## _write) TYPE ## _write_wrapper;
 %inline %{
-PyObject* type ## _write_wrapper(const_ ## type p) {
+PyObject* TYPE ## _write_wrapper(const_ ## TYPE p) {
     PyObject* data = NULL;
     msgpack_sbuffer sbuf;
     msgpack_packer pk;
     msgpack_sbuffer_init(&sbuf);
     msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
 
-    SECStatus rv = type ## _write(p, &pk);
+    SECStatus rv = TYPE ## _write(p, &pk);
     if (rv == SECSuccess) {
         // move the data outside of this wrapper
         data = PyBytes_FromStringAndSize(sbuf.data, sbuf.size);
@@ -224,9 +225,9 @@ PyObject* type ## _write_wrapper(const_ ## type p) {
 %}
 %enddef
 
-MSGPACK_WRITE_WRAPPER(PrioPacketVerify1)
-MSGPACK_WRITE_WRAPPER(PrioPacketVerify2)
-MSGPACK_WRITE_WRAPPER(PrioTotalShare)
+MSGPACK_WRITE(PrioPacketVerify1)
+MSGPACK_WRITE(PrioPacketVerify2)
+MSGPACK_WRITE(PrioTotalShare)
 
 
 // Unfortunately, unpacking also requires some manual work. We take the binary message and
@@ -236,17 +237,18 @@ MSGPACK_WRITE_WRAPPER(PrioTotalShare)
     (const unsigned char *data, unsigned int len)
 }
 
-%define MSGPACK_READ_WRAPPER(type)
-%ignore type ## _read;
+%define MSGPACK_READ(TYPE)
+%ignore TYPE ## _read;
+%rename(TYPE ## _read) TYPE ## _read_wrapper;
 %inline %{
-SECStatus type ## _read_wrapper(type p, const unsigned char *data, unsigned int len, const_PrioConfig cfg) {
+SECStatus TYPE ## _read_wrapper(TYPE p, const unsigned char *data, unsigned int len, const_PrioConfig cfg) {
     SECStatus rv = SECFailure;
     msgpack_unpacker upk;
     bool result = msgpack_unpacker_init(&upk, len+1);
     if (result) {
         memcpy(msgpack_unpacker_buffer(&upk), data, len);
         msgpack_unpacker_buffer_consumed(&upk, len);
-        rv = type ## _read(p, &upk, cfg);
+        rv = TYPE ## _read(p, &upk, cfg);
     }
     msgpack_unpacker_destroy(&upk);
     return rv;
@@ -254,9 +256,9 @@ SECStatus type ## _read_wrapper(type p, const unsigned char *data, unsigned int 
 %}
 %enddef
 
-MSGPACK_READ_WRAPPER(PrioPacketVerify1)
-MSGPACK_READ_WRAPPER(PrioPacketVerify2)
-MSGPACK_READ_WRAPPER(PrioTotalShare)
+MSGPACK_READ(PrioPacketVerify1)
+MSGPACK_READ(PrioPacketVerify2)
+MSGPACK_READ(PrioTotalShare)
 
 
 %include "libprio/include/mprio.h"

--- a/libprio_wrap.c
+++ b/libprio_wrap.c
@@ -3081,6 +3081,58 @@ void PrivateKey_PyCapsule_clear(PyObject *capsule) {
 }
 
 
+    PyObject* PublicKey_export_wrapper(const_PublicKey key) {
+        SECStatus rv = SECFailure;
+        unsigned char data[CURVE25519_KEY_LEN];
+
+        rv = PublicKey_export(key, data, CURVE25519_KEY_LEN);
+        if (rv != SECSuccess) {
+            PyErr_SetString(PyExc_RuntimeError, "Error exporting PublicKey");
+            return NULL;
+        }
+        return PyBytes_FromStringAndSize((char *)data, CURVE25519_KEY_LEN);
+    }
+
+
+    PyObject* PublicKey_export_hex_wrapper(const_PublicKey key) {
+        SECStatus rv = SECFailure;
+        unsigned char data[CURVE25519_KEY_LEN_HEX+1];
+
+        rv = PublicKey_export_hex(key, data, CURVE25519_KEY_LEN_HEX+1);
+        if (rv != SECSuccess) {
+            PyErr_SetString(PyExc_RuntimeError, "Error exporting PublicKey");
+            return NULL;
+        }
+        return PyBytes_FromStringAndSize((char *)data, CURVE25519_KEY_LEN_HEX+1);
+    }
+
+
+    PyObject* PrivateKey_export_wrapper(PrivateKey key) {
+        SECStatus rv = SECFailure;
+        unsigned char data[CURVE25519_KEY_LEN];
+
+        rv = PrivateKey_export(key, data, CURVE25519_KEY_LEN);
+        if (rv != SECSuccess) {
+            PyErr_SetString(PyExc_RuntimeError, "Error exporting PrivateKey");
+            return NULL;
+        }
+        return PyBytes_FromStringAndSize((char *)data, CURVE25519_KEY_LEN);
+    }
+
+
+    PyObject* PrivateKey_export_hex_wrapper(PrivateKey key) {
+        SECStatus rv = SECFailure;
+        unsigned char data[CURVE25519_KEY_LEN_HEX+1];
+
+        rv = PrivateKey_export_hex(key, data, CURVE25519_KEY_LEN_HEX+1);
+        if (rv != SECSuccess) {
+            PyErr_SetString(PyExc_RuntimeError, "Error exporting PrivateKey");
+            return NULL;
+        }
+        return PyBytes_FromStringAndSize((char *)data, CURVE25519_KEY_LEN_HEX+1);
+    }
+
+
 PyObject* PrioPacketVerify1_write_wrapper(const_PrioPacketVerify1 p) {
     PyObject* data = NULL;
     msgpack_sbuffer sbuf;
@@ -3407,6 +3459,78 @@ SWIG_AsVal_int (PyObject * obj, int *val)
 #ifdef __cplusplus
 extern "C" {
 #endif
+SWIGINTERN PyObject *_wrap_PublicKey_export(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  const_PublicKey arg1 = (const_PublicKey) 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:PublicKey_export",&obj0)) SWIG_fail;
+  {
+    arg1 = PyCapsule_GetPointer(obj0, "PublicKey");
+  }
+  result = (PyObject *)PublicKey_export_wrapper((SECKEYPublicKey const *)arg1);
+  resultobj = result;
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PublicKey_export_hex(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  const_PublicKey arg1 = (const_PublicKey) 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:PublicKey_export_hex",&obj0)) SWIG_fail;
+  {
+    arg1 = PyCapsule_GetPointer(obj0, "PublicKey");
+  }
+  result = (PyObject *)PublicKey_export_hex_wrapper((SECKEYPublicKey const *)arg1);
+  resultobj = result;
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PrivateKey_export(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  PrivateKey arg1 = (PrivateKey) 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:PrivateKey_export",&obj0)) SWIG_fail;
+  {
+    arg1 = PyCapsule_GetPointer(obj0, "PrivateKey");
+  }
+  result = (PyObject *)PrivateKey_export_wrapper(arg1);
+  resultobj = result;
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_PrivateKey_export_hex(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  PrivateKey arg1 = (PrivateKey) 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:PrivateKey_export_hex",&obj0)) SWIG_fail;
+  {
+    arg1 = PyCapsule_GetPointer(obj0, "PrivateKey");
+  }
+  result = (PyObject *)PrivateKey_export_hex_wrapper(arg1);
+  resultobj = result;
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_PrioPacketVerify1_write_wrapper(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   const_PrioPacketVerify1 arg1 = (const_PrioPacketVerify1) 0 ;
@@ -3772,6 +3896,55 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_PrivateKey_import(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  PrivateKey *arg1 = (PrivateKey *) 0 ;
+  unsigned char *arg2 = (unsigned char *) 0 ;
+  unsigned int arg3 ;
+  unsigned char *arg4 = (unsigned char *) 0 ;
+  unsigned int arg5 ;
+  PrivateKey tmp1 = NULL ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  SECStatus result;
+  
+  {
+    arg1 = &tmp1;
+  }
+  if (!PyArg_ParseTuple(args,(char *)"OO:PrivateKey_import",&obj0,&obj1)) SWIG_fail;
+  {
+    if (!PyBytes_Check(obj0)) {
+      PyErr_SetString(PyExc_ValueError, "Expecting a byte string");
+      SWIG_fail;
+    }
+    arg2 = (unsigned char*) PyBytes_AsString(obj0);
+    arg3 = (unsigned int) PyBytes_Size(obj0);
+  }
+  {
+    if (!PyBytes_Check(obj1)) {
+      PyErr_SetString(PyExc_ValueError, "Expecting a byte string");
+      SWIG_fail;
+    }
+    arg4 = (unsigned char*) PyBytes_AsString(obj1);
+    arg5 = (unsigned int) PyBytes_Size(obj1);
+  }
+  result = PrivateKey_import(arg1,(unsigned char const *)arg2,arg3,(unsigned char const *)arg4,arg5);
+  {
+    if (result != SECSuccess) {
+      PyErr_SetString(PyExc_RuntimeError, "PrivateKey_import was not succesful.");
+      SWIG_fail;
+    }
+    resultobj = Py_None;
+  }
+  {
+    resultobj = SWIG_Python_AppendOutput(resultobj,PyCapsule_New(*arg1, "PrivateKey", PrivateKey_PyCapsule_clear));
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_PublicKey_import_hex(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   PublicKey *arg1 = (PublicKey *) 0 ;
@@ -3810,69 +3983,48 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_PublicKey_export(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_PrivateKey_import_hex(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  const_PublicKey arg1 = (const_PublicKey) 0 ;
-  unsigned char *arg2 ;
-  unsigned char tmp2[32] ;
+  PrivateKey *arg1 = (PrivateKey *) 0 ;
+  unsigned char *arg2 = (unsigned char *) 0 ;
+  unsigned int arg3 ;
+  unsigned char *arg4 = (unsigned char *) 0 ;
+  unsigned int arg5 ;
+  PrivateKey tmp1 = NULL ;
   PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
   SECStatus result;
   
   {
-    arg2 = tmp2;
+    arg1 = &tmp1;
   }
-  if (!PyArg_ParseTuple(args,(char *)"O:PublicKey_export",&obj0)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OO:PrivateKey_import_hex",&obj0,&obj1)) SWIG_fail;
   {
-    arg1 = PyCapsule_GetPointer(obj0, "PublicKey");
+    if (!PyBytes_Check(obj0)) {
+      PyErr_SetString(PyExc_ValueError, "Expecting a byte string");
+      SWIG_fail;
+    }
+    arg2 = (unsigned char*) PyBytes_AsString(obj0);
+    arg3 = (unsigned int) PyBytes_Size(obj0);
   }
-  result = PublicKey_export((SECKEYPublicKey const *)arg1,arg2);
+  {
+    if (!PyBytes_Check(obj1)) {
+      PyErr_SetString(PyExc_ValueError, "Expecting a byte string");
+      SWIG_fail;
+    }
+    arg4 = (unsigned char*) PyBytes_AsString(obj1);
+    arg5 = (unsigned int) PyBytes_Size(obj1);
+  }
+  result = PrivateKey_import_hex(arg1,(unsigned char const *)arg2,arg3,(unsigned char const *)arg4,arg5);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PublicKey_export was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrivateKey_import_hex was not succesful.");
       SWIG_fail;
     }
     resultobj = Py_None;
   }
   {
-    resultobj = SWIG_Python_AppendOutput(
-      resultobj,
-      PyBytes_FromStringAndSize((const char*)arg2, 32)
-      );
-  }
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_PublicKey_export_hex(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  const_PublicKey arg1 = (const_PublicKey) 0 ;
-  unsigned char *arg2 ;
-  unsigned char tmp2[64+1] ;
-  PyObject * obj0 = 0 ;
-  SECStatus result;
-  
-  {
-    arg2 = tmp2;
-  }
-  if (!PyArg_ParseTuple(args,(char *)"O:PublicKey_export_hex",&obj0)) SWIG_fail;
-  {
-    arg1 = PyCapsule_GetPointer(obj0, "PublicKey");
-  }
-  result = PublicKey_export_hex((SECKEYPublicKey const *)arg1,arg2);
-  {
-    if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PublicKey_export_hex was not succesful.");
-      SWIG_fail;
-    }
-    resultobj = Py_None;
-  }
-  {
-    resultobj = SWIG_Python_AppendOutput(
-      resultobj,
-      PyBytes_FromStringAndSize((const char*)arg2, 64+1)
-      );
+    resultobj = SWIG_Python_AppendOutput(resultobj,PyCapsule_New(*arg1, "PrivateKey", PrivateKey_PyCapsule_clear));
   }
   return resultobj;
 fail:
@@ -4312,6 +4464,10 @@ fail:
 
 static PyMethodDef SwigMethods[] = {
 	 { (char *)"SWIG_PyInstanceMethod_New", (PyCFunction)SWIG_PyInstanceMethod_New, METH_O, NULL},
+	 { (char *)"PublicKey_export", _wrap_PublicKey_export, METH_VARARGS, NULL},
+	 { (char *)"PublicKey_export_hex", _wrap_PublicKey_export_hex, METH_VARARGS, NULL},
+	 { (char *)"PrivateKey_export", _wrap_PrivateKey_export, METH_VARARGS, NULL},
+	 { (char *)"PrivateKey_export_hex", _wrap_PrivateKey_export_hex, METH_VARARGS, NULL},
 	 { (char *)"PrioPacketVerify1_write_wrapper", _wrap_PrioPacketVerify1_write_wrapper, METH_VARARGS, NULL},
 	 { (char *)"PrioPacketVerify2_write_wrapper", _wrap_PrioPacketVerify2_write_wrapper, METH_VARARGS, NULL},
 	 { (char *)"PrioTotalShare_write_wrapper", _wrap_PrioTotalShare_write_wrapper, METH_VARARGS, NULL},
@@ -4325,9 +4481,9 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"PrioConfig_newTest", _wrap_PrioConfig_newTest, METH_VARARGS, NULL},
 	 { (char *)"Keypair_new", _wrap_Keypair_new, METH_VARARGS, NULL},
 	 { (char *)"PublicKey_import", _wrap_PublicKey_import, METH_VARARGS, NULL},
+	 { (char *)"PrivateKey_import", _wrap_PrivateKey_import, METH_VARARGS, NULL},
 	 { (char *)"PublicKey_import_hex", _wrap_PublicKey_import_hex, METH_VARARGS, NULL},
-	 { (char *)"PublicKey_export", _wrap_PublicKey_export, METH_VARARGS, NULL},
-	 { (char *)"PublicKey_export_hex", _wrap_PublicKey_export_hex, METH_VARARGS, NULL},
+	 { (char *)"PrivateKey_import_hex", _wrap_PrivateKey_import_hex, METH_VARARGS, NULL},
 	 { (char *)"PrioClient_encode", _wrap_PrioClient_encode, METH_VARARGS, NULL},
 	 { (char *)"PrioPRGSeed_randomize", _wrap_PrioPRGSeed_randomize, METH_VARARGS, NULL},
 	 { (char *)"PrioServer_new", _wrap_PrioServer_new, METH_VARARGS, NULL},
@@ -4350,7 +4506,7 @@ static PyMethodDef SwigMethods[] = {
 
 static swig_type_info _swigt__p_PrioServerId = {"_p_PrioServerId", "enum PrioServerId *|PrioServerId *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_SECKEYPrivateKey = {"_p_SECKEYPrivateKey", "PrivateKey|SECKEYPrivateKey *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_SECKEYPublicKey = {"_p_SECKEYPublicKey", "SECKEYPublicKey *|PublicKey|const_PublicKey", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_SECKEYPublicKey = {"_p_SECKEYPublicKey", "SECKEYPublicKey *|const_PublicKey|PublicKey", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_a_AES_128_KEY_LENGTH__unsigned_char = {"_p_a_AES_128_KEY_LENGTH__unsigned_char", "unsigned char (*)[AES_128_KEY_LENGTH]|PrioPRGSeed *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_bool = {"_p_bool", "bool *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};

--- a/libprio_wrap.c
+++ b/libprio_wrap.c
@@ -3531,13 +3531,13 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_PrioPacketVerify1_write_wrapper(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_PrioPacketVerify1_write(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   const_PrioPacketVerify1 arg1 = (const_PrioPacketVerify1) 0 ;
   PyObject * obj0 = 0 ;
   PyObject *result = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"O:PrioPacketVerify1_write_wrapper",&obj0)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"O:PrioPacketVerify1_write",&obj0)) SWIG_fail;
   {
     arg1 = PyCapsule_GetPointer(obj0, "PrioPacketVerify1");
   }
@@ -3549,13 +3549,13 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_PrioPacketVerify2_write_wrapper(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_PrioPacketVerify2_write(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   const_PrioPacketVerify2 arg1 = (const_PrioPacketVerify2) 0 ;
   PyObject * obj0 = 0 ;
   PyObject *result = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"O:PrioPacketVerify2_write_wrapper",&obj0)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"O:PrioPacketVerify2_write",&obj0)) SWIG_fail;
   {
     arg1 = PyCapsule_GetPointer(obj0, "PrioPacketVerify2");
   }
@@ -3567,13 +3567,13 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_PrioTotalShare_write_wrapper(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_PrioTotalShare_write(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   const_PrioTotalShare arg1 = (const_PrioTotalShare) 0 ;
   PyObject * obj0 = 0 ;
   PyObject *result = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"O:PrioTotalShare_write_wrapper",&obj0)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"O:PrioTotalShare_write",&obj0)) SWIG_fail;
   {
     arg1 = PyCapsule_GetPointer(obj0, "PrioTotalShare");
   }
@@ -3585,7 +3585,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_PrioPacketVerify1_read_wrapper(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_PrioPacketVerify1_read(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   PrioPacketVerify1 arg1 = (PrioPacketVerify1) 0 ;
   unsigned char *arg2 = (unsigned char *) 0 ;
@@ -3596,7 +3596,7 @@ SWIGINTERN PyObject *_wrap_PrioPacketVerify1_read_wrapper(PyObject *SWIGUNUSEDPA
   PyObject * obj2 = 0 ;
   SECStatus result;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOO:PrioPacketVerify1_read_wrapper",&obj0,&obj1,&obj2)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOO:PrioPacketVerify1_read",&obj0,&obj1,&obj2)) SWIG_fail;
   {
     arg1 = PyCapsule_GetPointer(obj0, "PrioPacketVerify1");
   }
@@ -3614,7 +3614,7 @@ SWIGINTERN PyObject *_wrap_PrioPacketVerify1_read_wrapper(PyObject *SWIGUNUSEDPA
   result = PrioPacketVerify1_read_wrapper(arg1,(unsigned char const *)arg2,arg3,(struct prio_config const *)arg4);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify1_read_wrapper was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify1_read was not succesful.");
       SWIG_fail;
     }
     resultobj = Py_None;
@@ -3625,7 +3625,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_PrioPacketVerify2_read_wrapper(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_PrioPacketVerify2_read(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   PrioPacketVerify2 arg1 = (PrioPacketVerify2) 0 ;
   unsigned char *arg2 = (unsigned char *) 0 ;
@@ -3636,7 +3636,7 @@ SWIGINTERN PyObject *_wrap_PrioPacketVerify2_read_wrapper(PyObject *SWIGUNUSEDPA
   PyObject * obj2 = 0 ;
   SECStatus result;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOO:PrioPacketVerify2_read_wrapper",&obj0,&obj1,&obj2)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOO:PrioPacketVerify2_read",&obj0,&obj1,&obj2)) SWIG_fail;
   {
     arg1 = PyCapsule_GetPointer(obj0, "PrioPacketVerify2");
   }
@@ -3654,7 +3654,7 @@ SWIGINTERN PyObject *_wrap_PrioPacketVerify2_read_wrapper(PyObject *SWIGUNUSEDPA
   result = PrioPacketVerify2_read_wrapper(arg1,(unsigned char const *)arg2,arg3,(struct prio_config const *)arg4);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify2_read_wrapper was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioPacketVerify2_read was not succesful.");
       SWIG_fail;
     }
     resultobj = Py_None;
@@ -3665,7 +3665,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_PrioTotalShare_read_wrapper(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_PrioTotalShare_read(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   PrioTotalShare arg1 = (PrioTotalShare) 0 ;
   unsigned char *arg2 = (unsigned char *) 0 ;
@@ -3676,7 +3676,7 @@ SWIGINTERN PyObject *_wrap_PrioTotalShare_read_wrapper(PyObject *SWIGUNUSEDPARM(
   PyObject * obj2 = 0 ;
   SECStatus result;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOO:PrioTotalShare_read_wrapper",&obj0,&obj1,&obj2)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOO:PrioTotalShare_read",&obj0,&obj1,&obj2)) SWIG_fail;
   {
     arg1 = PyCapsule_GetPointer(obj0, "PrioTotalShare");
   }
@@ -3694,7 +3694,7 @@ SWIGINTERN PyObject *_wrap_PrioTotalShare_read_wrapper(PyObject *SWIGUNUSEDPARM(
   result = PrioTotalShare_read_wrapper(arg1,(unsigned char const *)arg2,arg3,(struct prio_config const *)arg4);
   {
     if (result != SECSuccess) {
-      PyErr_SetString(PyExc_RuntimeError, "PrioTotalShare_read_wrapper was not succesful.");
+      PyErr_SetString(PyExc_RuntimeError, "PrioTotalShare_read was not succesful.");
       SWIG_fail;
     }
     resultobj = Py_None;
@@ -4468,12 +4468,12 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"PublicKey_export_hex", _wrap_PublicKey_export_hex, METH_VARARGS, NULL},
 	 { (char *)"PrivateKey_export", _wrap_PrivateKey_export, METH_VARARGS, NULL},
 	 { (char *)"PrivateKey_export_hex", _wrap_PrivateKey_export_hex, METH_VARARGS, NULL},
-	 { (char *)"PrioPacketVerify1_write_wrapper", _wrap_PrioPacketVerify1_write_wrapper, METH_VARARGS, NULL},
-	 { (char *)"PrioPacketVerify2_write_wrapper", _wrap_PrioPacketVerify2_write_wrapper, METH_VARARGS, NULL},
-	 { (char *)"PrioTotalShare_write_wrapper", _wrap_PrioTotalShare_write_wrapper, METH_VARARGS, NULL},
-	 { (char *)"PrioPacketVerify1_read_wrapper", _wrap_PrioPacketVerify1_read_wrapper, METH_VARARGS, NULL},
-	 { (char *)"PrioPacketVerify2_read_wrapper", _wrap_PrioPacketVerify2_read_wrapper, METH_VARARGS, NULL},
-	 { (char *)"PrioTotalShare_read_wrapper", _wrap_PrioTotalShare_read_wrapper, METH_VARARGS, NULL},
+	 { (char *)"PrioPacketVerify1_write", _wrap_PrioPacketVerify1_write, METH_VARARGS, NULL},
+	 { (char *)"PrioPacketVerify2_write", _wrap_PrioPacketVerify2_write, METH_VARARGS, NULL},
+	 { (char *)"PrioTotalShare_write", _wrap_PrioTotalShare_write, METH_VARARGS, NULL},
+	 { (char *)"PrioPacketVerify1_read", _wrap_PrioPacketVerify1_read, METH_VARARGS, NULL},
+	 { (char *)"PrioPacketVerify2_read", _wrap_PrioPacketVerify2_read, METH_VARARGS, NULL},
+	 { (char *)"PrioTotalShare_read", _wrap_PrioTotalShare_read, METH_VARARGS, NULL},
 	 { (char *)"Prio_init", _wrap_Prio_init, METH_VARARGS, NULL},
 	 { (char *)"Prio_clear", _wrap_Prio_clear, METH_VARARGS, NULL},
 	 { (char *)"PrioConfig_new", _wrap_PrioConfig_new, METH_VARARGS, NULL},

--- a/prio/lib/prio.py
+++ b/prio/lib/prio.py
@@ -96,6 +96,22 @@ except __builtin__.Exception:
     _newclass = 0
 
 
+def PublicKey_export(key):
+    return _prio.PublicKey_export(key)
+PublicKey_export = _prio.PublicKey_export
+
+def PublicKey_export_hex(key):
+    return _prio.PublicKey_export_hex(key)
+PublicKey_export_hex = _prio.PublicKey_export_hex
+
+def PrivateKey_export(key):
+    return _prio.PrivateKey_export(key)
+PrivateKey_export = _prio.PrivateKey_export
+
+def PrivateKey_export_hex(key):
+    return _prio.PrivateKey_export_hex(key)
+PrivateKey_export_hex = _prio.PrivateKey_export_hex
+
 def PrioPacketVerify1_write_wrapper(p):
     return _prio.PrioPacketVerify1_write_wrapper(p)
 PrioPacketVerify1_write_wrapper = _prio.PrioPacketVerify1_write_wrapper
@@ -132,16 +148,16 @@ def Prio_clear():
     return _prio.Prio_clear()
 Prio_clear = _prio.Prio_clear
 
-def PrioConfig_new(n_fields, server_a, server_b, batch_id):
-    return _prio.PrioConfig_new(n_fields, server_a, server_b, batch_id)
+def PrioConfig_new(nFields, serverA, serverB, batchId):
+    return _prio.PrioConfig_new(nFields, serverA, serverB, batchId)
 PrioConfig_new = _prio.PrioConfig_new
 
 def PrioConfig_numDataFields(cfg):
     return _prio.PrioConfig_numDataFields(cfg)
 PrioConfig_numDataFields = _prio.PrioConfig_numDataFields
 
-def PrioConfig_newTest(n_fields):
-    return _prio.PrioConfig_newTest(n_fields)
+def PrioConfig_newTest(nFields):
+    return _prio.PrioConfig_newTest(nFields)
 PrioConfig_newTest = _prio.PrioConfig_newTest
 
 def Keypair_new():
@@ -152,17 +168,17 @@ def PublicKey_import(data):
     return _prio.PublicKey_import(data)
 PublicKey_import = _prio.PublicKey_import
 
-def PublicKey_import_hex(hex_data):
-    return _prio.PublicKey_import_hex(hex_data)
+def PrivateKey_import(privData, pubData):
+    return _prio.PrivateKey_import(privData, pubData)
+PrivateKey_import = _prio.PrivateKey_import
+
+def PublicKey_import_hex(hexData):
+    return _prio.PublicKey_import_hex(hexData)
 PublicKey_import_hex = _prio.PublicKey_import_hex
 
-def PublicKey_export(pk):
-    return _prio.PublicKey_export(pk)
-PublicKey_export = _prio.PublicKey_export
-
-def PublicKey_export_hex(pk):
-    return _prio.PublicKey_export_hex(pk)
-PublicKey_export_hex = _prio.PublicKey_export_hex
+def PrivateKey_import_hex(privHexData, pubHexData):
+    return _prio.PrivateKey_import_hex(privHexData, pubHexData)
+PrivateKey_import_hex = _prio.PrivateKey_import_hex
 
 def PrioClient_encode(cfg, data_in):
     return _prio.PrioClient_encode(cfg, data_in)
@@ -172,8 +188,8 @@ def PrioPRGSeed_randomize():
     return _prio.PrioPRGSeed_randomize()
 PrioPRGSeed_randomize = _prio.PrioPRGSeed_randomize
 
-def PrioServer_new(cfg, server_idx, server_priv, server_shared_secret):
-    return _prio.PrioServer_new(cfg, server_idx, server_priv, server_shared_secret)
+def PrioServer_new(cfg, serverIdx, serverPriv, serverSharedSecret):
+    return _prio.PrioServer_new(cfg, serverIdx, serverPriv, serverSharedSecret)
 PrioServer_new = _prio.PrioServer_new
 
 def PrioVerifier_new(s):

--- a/prio/lib/prio.py
+++ b/prio/lib/prio.py
@@ -112,29 +112,29 @@ def PrivateKey_export_hex(key):
     return _prio.PrivateKey_export_hex(key)
 PrivateKey_export_hex = _prio.PrivateKey_export_hex
 
-def PrioPacketVerify1_write_wrapper(p):
-    return _prio.PrioPacketVerify1_write_wrapper(p)
-PrioPacketVerify1_write_wrapper = _prio.PrioPacketVerify1_write_wrapper
+def PrioPacketVerify1_write(p):
+    return _prio.PrioPacketVerify1_write(p)
+PrioPacketVerify1_write = _prio.PrioPacketVerify1_write
 
-def PrioPacketVerify2_write_wrapper(p):
-    return _prio.PrioPacketVerify2_write_wrapper(p)
-PrioPacketVerify2_write_wrapper = _prio.PrioPacketVerify2_write_wrapper
+def PrioPacketVerify2_write(p):
+    return _prio.PrioPacketVerify2_write(p)
+PrioPacketVerify2_write = _prio.PrioPacketVerify2_write
 
-def PrioTotalShare_write_wrapper(p):
-    return _prio.PrioTotalShare_write_wrapper(p)
-PrioTotalShare_write_wrapper = _prio.PrioTotalShare_write_wrapper
+def PrioTotalShare_write(p):
+    return _prio.PrioTotalShare_write(p)
+PrioTotalShare_write = _prio.PrioTotalShare_write
 
-def PrioPacketVerify1_read_wrapper(p, data, cfg):
-    return _prio.PrioPacketVerify1_read_wrapper(p, data, cfg)
-PrioPacketVerify1_read_wrapper = _prio.PrioPacketVerify1_read_wrapper
+def PrioPacketVerify1_read(p, data, cfg):
+    return _prio.PrioPacketVerify1_read(p, data, cfg)
+PrioPacketVerify1_read = _prio.PrioPacketVerify1_read
 
-def PrioPacketVerify2_read_wrapper(p, data, cfg):
-    return _prio.PrioPacketVerify2_read_wrapper(p, data, cfg)
-PrioPacketVerify2_read_wrapper = _prio.PrioPacketVerify2_read_wrapper
+def PrioPacketVerify2_read(p, data, cfg):
+    return _prio.PrioPacketVerify2_read(p, data, cfg)
+PrioPacketVerify2_read = _prio.PrioPacketVerify2_read
 
-def PrioTotalShare_read_wrapper(p, data, cfg):
-    return _prio.PrioTotalShare_read_wrapper(p, data, cfg)
-PrioTotalShare_read_wrapper = _prio.PrioTotalShare_read_wrapper
+def PrioTotalShare_read(p, data, cfg):
+    return _prio.PrioTotalShare_read(p, data, cfg)
+PrioTotalShare_read = _prio.PrioTotalShare_read
 CURVE25519_KEY_LEN = _prio.CURVE25519_KEY_LEN
 CURVE25519_KEY_LEN_HEX = _prio.CURVE25519_KEY_LEN_HEX
 PRIO_SERVER_A = _prio.PRIO_SERVER_A

--- a/prio/prio.py
+++ b/prio/prio.py
@@ -53,6 +53,7 @@ class PublicKey:
         :param data: a bytestring of length `CURVE25519_KEY_LEN`
         """
         self.instance = prio.PublicKey_import(data)
+        return self
 
     def import_hex(self, data):
         """Import a curve25519 key from a case-insenstive hex string.
@@ -60,6 +61,7 @@ class PublicKey:
         :param data: a hex bytestring of length `CURVE25519_KEY_LEN_HEX`
         """
         self.instance = prio.PublicKey_import_hex(data)
+        return self
 
     def export_bin(self):
         """Export a curve25519 public key as a bytestring."""
@@ -77,6 +79,36 @@ class PublicKey:
 class PrivateKey:
     def __init__(self, instance=None):
         self.instance = instance
+
+    def import_bin(self, pvtdata, pubdata):
+        """Import a curve25519 key from a raw byte string.
+
+        :param pvtdata: a bytestring of length `CURVE25519_KEY_LEN`
+        :param pubdata: a bytestring of length `CURVE25519_KEY_LEN`
+        """
+        self.instance = prio.PrivateKey_import(pvtdata, pubdata)
+        return self
+
+    def import_hex(self, pvtdata, pubdata):
+        """Import a curve25519 key from a case-insenstive hex string.
+
+        :param pvtdata: a hex bytestring of length `CURVE25519_KEY_LEN_HEX`
+        :param pubdata: a hex bytestring of length `CURVE25519_KEY_LEN_HEX`
+        """
+        self.instance = prio.PrivateKey_import_hex(pvtdata, pubdata)
+
+    def export_bin(self):
+        """Export a curve25519 public key as a bytestring."""
+        if not self.instance:
+            return None
+        return prio.PrivateKey_export(self.instance)
+
+    def export_hex(self):
+        """Export a curve25519 public key as a NULL-terminated hex bytestring."""
+        if not self.instance:
+            return None
+        return prio.PrivateKey_export_hex(self.instance)
+
 
 class Client:
     def __init__(self, config):

--- a/prio/prio.py
+++ b/prio/prio.py
@@ -155,11 +155,11 @@ class PacketVerify1:
 
     def deserialize(self, config):
         if self._serial_data:
-            prio.PrioPacketVerify1_read_wrapper(self.instance, self._serial_data, config.instance)
+            prio.PrioPacketVerify1_read(self.instance, self._serial_data, config.instance)
         self._serial_data = None
 
     def __getstate__(self):
-        return prio.PrioPacketVerify1_write_wrapper(self.instance)
+        return prio.PrioPacketVerify1_write(self.instance)
 
     def __setstate__(self, state):
         self.instance = prio.PrioPacketVerify1_new()
@@ -175,11 +175,11 @@ class PacketVerify2:
 
     def deserialize(self, config):
         if self._serial_data:
-            prio.PrioPacketVerify2_read_wrapper(self.instance, self._serial_data, config.instance)
+            prio.PrioPacketVerify2_read(self.instance, self._serial_data, config.instance)
         self._serial_data = None
 
     def __getstate__(self):
-        return prio.PrioPacketVerify2_write_wrapper(self.instance)
+        return prio.PrioPacketVerify2_write(self.instance)
 
     def __setstate__(self, state):
         self.instance = prio.PrioPacketVerify2_new()
@@ -195,11 +195,11 @@ class TotalShare:
 
     def deserialize(self, config):
         if self._serial_data:
-            prio.PrioTotalShare_read_wrapper(self.instance, self._serial_data, config.instance)
+            prio.PrioTotalShare_read(self.instance, self._serial_data, config.instance)
         self._serial_data = None
 
     def __getstate__(self):
-        return prio.PrioTotalShare_write_wrapper(self.instance)
+        return prio.PrioTotalShare_write(self.instance)
 
     def __setstate__(self, state):
         self.instance = prio.PrioTotalShare_new()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -56,8 +56,7 @@ def test_client_agg(n_clients):
 
 def test_publickey_export():
     raw_bytes = bytes((3*x + 7) % 0xFF for x in range(libprio.CURVE25519_KEY_LEN))
-    pubkey = prio.PublicKey()
-    pubkey.import_bin(raw_bytes)
+    pubkey = prio.PublicKey().import_bin(raw_bytes)
     raw_bytes2 = pubkey.export_bin()
 
     assert raw_bytes == raw_bytes2
@@ -74,8 +73,7 @@ def test_publickey_import_hex(hex_bytes):
         0xAA, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11
     ])
 
-    pubkey = prio.PublicKey()
-    pubkey.import_hex(hex_bytes)
+    pubkey = prio.PublicKey().import_hex(hex_bytes)
     raw_bytes = pubkey.export_bin()
 
     assert raw_bytes == expect
@@ -96,8 +94,7 @@ def test_publickey_export_hex():
         0xC0, 0xD0, 0xE0, 0xF0, 0x00, 0x00, 0xFF, 0xEE, 0xDD, 0xCC, 0xBB,
         0xAA, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11
     ])
-    pubkey = prio.PublicKey()
-    pubkey.import_bin(raw_bytes)
+    pubkey = prio.PublicKey().import_bin(raw_bytes)
     hex_bytes = pubkey.export_hex()
     assert bytes(hex_bytes) == expect
 
@@ -106,3 +103,10 @@ def test_publickey_export_missing_key():
     pubkey = prio.PublicKey()
     assert pubkey.export_bin() is None
     assert pubkey.export_hex() is None
+
+def test_privatekey():
+    pvtkey, pubkey = prio.create_keypair()
+    pvtdata = pvtkey.export_bin()
+    pubdata = pubkey.export_bin()
+    new_pvtkey = prio.PrivateKey().import_bin(pvtdata, pubdata)
+    assert pvtdata == new_pvtkey.export_bin()

--- a/tests/test_lib_client.py
+++ b/tests/test_lib_client.py
@@ -83,3 +83,11 @@ def test_publickey_export_hex():
     pubkey = prio.PublicKey_import(raw_bytes)
     hex_bytes = prio.PublicKey_export_hex(pubkey)
     assert bytes(hex_bytes) == expect
+
+
+def test_privatekey_export():
+    pvtkey, pubkey = prio.Keypair_new()
+    pubdata = prio.PublicKey_export(pubkey)
+    pvtdata = prio.PrivateKey_export(pvtkey)
+    new_pvtkey = prio.PrivateKey_import(pvtdata, pubdata)
+    assert pvtdata == prio.PrivateKey_export(new_pvtkey)


### PR DESCRIPTION
This adds private key import/export added to libprio in mozilla/libprio#51.

This uses the `%rename` and `%ignore` directives to add a custom wrapper around the export functions now that the interface has changed. I rewrote the `MSGPACK_READ` and `MSGPACK_WRITE` macros to do the same thing. 

The PR also changed the casing of some of the argument, which broke some of the tests. The interface file has been changed accordingly.